### PR TITLE
feat: Bump version, update README for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Built with [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPac
 
 Releases in github repo are packaged for Thunderstore Mod Manager.
 
+* 0.0.6 Target latest BepInEx version 5.4.2105
 * 0.0.5 Update for latest version of BepInEx
 * 0.0.4 Update for latest version of BepInEx and ConfigurationManager
 * 0.0.3 Add config and ability to silence adult wolves

--- a/SilenceTameWolfCubMod.cs
+++ b/SilenceTameWolfCubMod.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 
 namespace ValheimTameMods
 {
-    [BepInPlugin("afilbert.ValheimSilenceTameWolfCubMod", "Valheim - Silence Tame Wolf Cub Howls", "0.0.5")]
+    [BepInPlugin("afilbert.ValheimSilenceTameWolfCubMod", "Valheim - Silence Tame Wolf Cub Howls", "0.0.6")]
     [BepInProcess("valheim.exe")]
     public class SilenceTameWolfCubMod : BaseUnityPlugin
     {

--- a/SilenceTameWolfCubMod.csproj
+++ b/SilenceTameWolfCubMod.csproj
@@ -59,5 +59,8 @@
     <Compile Include="SilenceTameWolfCubMod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This release simply bumps the target BepInEx version in the Thunderstore manifest. No behavioral changes