### PR TITLE
chore: Bump version to drop config req

### DIFF
--- a/SilenceTameWolfCubMod.cs
+++ b/SilenceTameWolfCubMod.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 
 namespace ValheimTameMods
 {
-    [BepInPlugin("afilbert.ValheimSilenceTameWolfCubMod", "Valheim - Silence Tame Wolf Cub Howls", "0.0.6")]
+    [BepInPlugin("afilbert.ValheimSilenceTameWolfCubMod", "Valheim - Silence Tame Wolf Cub Howls", "0.0.7")]
     [BepInProcess("valheim.exe")]
     public class SilenceTameWolfCubMod : BaseUnityPlugin
     {


### PR DESCRIPTION
This version bump facilitates issue #6. Removing specific config manager requirement in manifest.json allows for greater flexibility